### PR TITLE
:bug: 符号反転と小数点ボタンの不具合を修正

### DIFF
--- a/SimpleCalc/CalculationModel.swift
+++ b/SimpleCalc/CalculationModel.swift
@@ -98,12 +98,20 @@ class CalclationModel: ObservableObject {
         displayNumber = createRoundedNumber(decimalNumber: computation)
     }
 
-    func toggleNegative() {
+    func pushSignInversionButton() {
+        if case .calculate = mode {
+            editNumber.clear()
+            mode = .input
+        }
         editNumber.isNegative.toggle()
         displayNumber = editNumber.numeric
     }
 
-    func addPoint() {
+    func pushPointButton() {
+        if case .calculate = mode {
+            editNumber.clear()
+            mode = .input
+        }
         editNumber.appendPoint()
         displayNumber = editNumber.numeric
     }

--- a/SimpleCalc/ContentView.swift
+++ b/SimpleCalc/ContentView.swift
@@ -58,10 +58,10 @@ struct ContentView: View {
                 model.pushNumberButton(number)
 
             case .decimalPoint:
-                model.addPoint()
+                model.pushPointButton()
                 
             case .inversionＳign:
-                model.toggleNegative()
+                model.pushSignInversionButton()
 
             case .operation(let operationType):
                 model.pushOperateButton(operationType)

--- a/SimpleCalcTests/SimpleCalcTests.swift
+++ b/SimpleCalcTests/SimpleCalcTests.swift
@@ -237,8 +237,12 @@ class SimpleCalcTests: XCTestCase {
                            ["1","+","2","/","3","="],
                            ["1","+","2","*","3","c","4","="],
                            ["1","+","2","*","3","a","4","+","5","="],
+                           ["1","+",".","2","="],
+                           ["1","+","±","2","="],
+                           ["1","+",".","±","2","="],
+
         ]
-        let testResult = ["9","5","2","9","1","12","9"]
+        let testResult = ["9","5","2","9","1","12","9","1.2","-1","0.8"]
         for (index, buttons) in testButtons.enumerated() {
             var calc = ""
             for operate in buttons {
@@ -256,9 +260,9 @@ class SimpleCalcTests: XCTestCase {
 
     func pressButton(button: String) {
         if button == "±" {
-            model.toggleNegative()
+            model.pushSignInversionButton()
         } else if button == "." {
-            model.addPoint()
+            model.pushPointButton()
         } else if button == "c" {
             model.clear()
         } else if button == "a" {


### PR DESCRIPTION
# 概要
- .（小数点） / ±（符号切り替え)ボタンを押したときに入力モードが変更されないため思った値と違う結果となっていたのを修正